### PR TITLE
add filter for advanced settings manipulation

### DIFF
--- a/inc/post-type/edit.php
+++ b/inc/post-type/edit.php
@@ -327,6 +327,8 @@ class MB_CPT_Post_Type_Edit extends MB_CPT_Base_Edit {
 			),
 		);
 
+		$advanced_fields = apply_filters( 'rwmb_advanced_field_settings', $advanced_fields, $label_prefix, $args_prefix );
+
 		$code_fields = array(
 			array(
 				'name' => __( 'Function name', 'mb-custom-post-type' ),

--- a/inc/post-type/edit.php
+++ b/inc/post-type/edit.php
@@ -327,7 +327,7 @@ class MB_CPT_Post_Type_Edit extends MB_CPT_Base_Edit {
 			),
 		);
 
-		$advanced_fields = apply_filters( 'rwmb_advanced_field_settings', $advanced_fields, $label_prefix, $args_prefix );
+		$advanced_fields = apply_filters( 'mbcpt_advanced_fields', $advanced_fields, $label_prefix, $args_prefix );
 
 		$code_fields = array(
 			array(


### PR DESCRIPTION
This filter will let third party plugin developers add their own custom settings for CPT registration.

I will use this to add a `show_in_graphql` field.